### PR TITLE
[ADD] Overrode SO to assign warehouse based on client's delivery address

### DIFF
--- a/ge05_team4/__init__.py
+++ b/ge05_team4/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/ge05_team4/__manifest__.py
+++ b/ge05_team4/__manifest__.py
@@ -1,0 +1,13 @@
+{
+    "name": "ge05_team04",
+    "summary": "Distance based warehouse computation on SO",
+    "description": """Changed Sales Orders so that the nearest existing warehouse
+    to the specified delivery order is assigned to it automaticaly. 
+    Task Id:3427342 Dev: Odoo Team 4""",
+   'license': 'OPL-1',
+    "version": "1.0.0",
+    "depends": ["sale_stock"],
+    "author": "Odoo,Inc.",
+    "website": "www.odoo.com",
+    "application": False,
+}

--- a/ge05_team4/models/__init__.py
+++ b/ge05_team4/models/__init__.py
@@ -1,0 +1,1 @@
+from . import sales_order

--- a/ge05_team4/models/sales_order.py
+++ b/ge05_team4/models/sales_order.py
@@ -1,0 +1,25 @@
+from odoo import api, models
+
+
+
+class SaleOrder(models.Model):
+    _inherit = "sale.order"
+
+    @api.depends('user_id', 'company_id')
+    def _compute_warehouse_id(self):
+        for order in self:
+            delivery_state = self.partner_id.state_id.name
+
+            west_coast_locations = {'Washington', 'Oregon', 'California', 'Nevada', 'Idaho', 'Utah', 'Arizona','Montana', 'Wyoming', 'Colorado', 'New Mexico'}
+            east_coast_locations = { 'Maine', 'New Hampshire', 'Vermont', 'Massachusetts', 'Rhode Island', 'Connecticut', 'New York', 'New Jersey', 'Delaware', 'Maryland', 'Virginia', 'West Virginia', 'North Carolina', 'South Carolina', 'Georgia', 'Florida'}
+            
+            if delivery_state in west_coast_locations:
+                order.warehouse_id = self.env['stock.warehouse'].search([('name','=','Buffalo Dealership')])
+                 # No external id, created
+            elif delivery_state in east_coast_locations:
+                order.warehouse_id = self.env['stock.warehouse'].search([('name','=','San Francisco Dealership')]) 
+                # No external id, created
+            else:
+                order.warehouse_id = self.env.ref('stock.warehouse0')
+                
+                


### PR DESCRIPTION
Inherited and overrode sale order to assign automatically the delivery warehouse based on client's delivery address