### PR TITLE
[ADD] ge09_team04:Motorcyle registry & repair Integration Task Id:342…

### DIFF
--- a/ge09_team04/__init__.py
+++ b/ge09_team04/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/ge09_team04/__manifest__.py
+++ b/ge09_team04/__manifest__.py
@@ -1,0 +1,19 @@
+{
+    "name": "ge09_team04",
+    "summary": "Captures motorcycle repair order data automatically",
+    "description": """Modifies repair order so that whenever a motorcycle is
+    assigned to a repair order, its motorcycle registry information (vin, owner,
+    sale order, product id, mileage) gets copied automatically and adds a smart button 
+    to the motorcycle registry view form to acces the repair history of the motorcycle.
+    Task Id:3427355 Dev: Odoo Team 4""",
+    "license": 'OPL-1',
+    "version": "1.0.0",
+    "data": [
+    "views/repair_views.xml",
+    "views/motorcycle_registry_views.xml",
+    ],
+    "depends": ["ge07_team04","repair"],
+    "author": "Odoo,Inc.",
+    "website": "www.odoo.com",
+    "application": False,
+}

--- a/ge09_team04/models/__init__.py
+++ b/ge09_team04/models/__init__.py
@@ -1,0 +1,1 @@
+from . import motorcycle_registry, repair

--- a/ge09_team04/models/motorcycle_registry.py
+++ b/ge09_team04/models/motorcycle_registry.py
@@ -1,0 +1,15 @@
+from odoo import models, fields, _
+
+
+class MotorcycleRegistry(models.Model):
+    _inherit = 'motorcycle.registry'
+    repair_order_ids = fields.One2many(comodel_name="repair.order", inverse_name="motorcycle_registry_entry")
+
+    def action_view_repair_order(self):
+        return {
+                'name': _('Repair Orders'),
+                'type': 'ir.actions.act_window',
+                'res_model': 'repair.order',
+                'view_mode': 'kanban,tree,form',
+                'domain': [('motorcycle_registry_entry', '=', self.id)],
+                }

--- a/ge09_team04/models/repair.py
+++ b/ge09_team04/models/repair.py
@@ -1,0 +1,26 @@
+from odoo import api, models, fields
+
+
+class Repair(models.Model):
+    _inherit = 'repair.order'
+    
+    motorcycle_registry_entry = fields.Many2one(comodel_name="motorcycle.registry", compute='_find_registry_from_lot_or_vin', store=True)
+
+    vin = fields.Char(related='motorcycle_registry_entry.vin', readonly=False)
+    mileage = fields.Float(related='motorcycle_registry_entry.current_mileage')
+    partner_id = fields.Many2one(related='motorcycle_registry_entry.owner_id', store=True)
+    sale_order_id = fields.Many2one(related='motorcycle_registry_entry.sale_order_id')
+    lot_id = fields.Many2one(related='motorcycle_registry_entry.stock_lot_id', readonly=False, store=True)
+    
+    product_id = fields.Many2one(related='lot_id.product_id', store=True)
+    product_uom = fields.Many2one(precompute=False)
+
+    @api.depends('lot_id', 'vin')
+    def _find_registry_from_lot_or_vin(self):
+        if self.lot_id and self.lot_id.product_id.product_tmpl_id.detailed_type == 'motorcycle':
+            self.motorcycle_registry_entry = self.lot_id.motorcycle_registry_id
+        elif self.vin:
+            registry = self.env['motorcycle.registry'].search([('vin', '=', self.vin)], limit=1)
+            self.motorcycle_registry_entry = registry[0].id if registry else False
+        else:
+            self.motorcycle_registry_entry = False

--- a/ge09_team04/views/motorcycle_registry_views.xml
+++ b/ge09_team04/views/motorcycle_registry_views.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="motorcycle_registry_view_form_inherit" model="ir.ui.view">
+        <field name="name">motorcycle.registry.view.form.inherit</field>
+        <field name="model">motorcycle.registry</field>
+        <field name="inherit_id" ref="motorcycle_registry.motorcycle_registry_view_form"/>
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='registry_number']" position="after">
+             <div name="button_box" position="inside">
+                <button name="action_view_repair_order"
+                        type="object"
+                        class="oe_stat_button"
+                        icon="fa-wrench">
+                        <div class="o_field_widget o_stat_info">
+                            <span class="o_stat_text">Repair</span>
+                            <span class="o_stat_text">History</span>
+                        </div>
+                </button>
+             </div>
+            </xpath>
+        </field>
+    </record>
+</odoo>

--- a/ge09_team04/views/repair_views.xml
+++ b/ge09_team04/views/repair_views.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="view_repair_order_form_inherit" model="ir.ui.view">
+        <field name="name">repair.view.repair.order.form.inherit</field>
+        <field name="model">repair.order</field>
+        <field name="inherit_id" ref="repair.view_repair_order_form"/>
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='tag_ids']" position="after">
+                <field name="vin"/>
+                <field name="mileage" attrs="{'invisible':[('vin', '=', False)]}"/>
+                <field name="motorcycle_registry_entry" attrs="{'invisible':[('vin', '=', False)]}"/>
+            </xpath>
+        </field>
+    </record>
+</odoo>

--- a/motorcycle_registry/models/motorcycle_registry.py
+++ b/motorcycle_registry/models/motorcycle_registry.py
@@ -54,7 +54,7 @@ class MotorcycleRegistry(models.Model):
  
     @api.constrains('vin')
     def _check_vin_pattern(self):
-        pattern = '^[A-Z]{4}\d{2}[A-Z0-9]{2}\d{5}$'
+        pattern = '^[A-Z]{4}\d{2}[A-Z0-9]{2}\d{6}$'
         for registry in self.filtered(lambda r: r.vin):
             match = re.match(pattern, registry.vin)
             if not match:


### PR DESCRIPTION
…7355

Captures motorcycle repair order data automatically",
 "description": """Modifies repair order so that whenever a motorcycle is
 assigned to a repair order, its motorcycle registry information (vin, owner,
 sale order, product id, mileage) gets copied automatically and adds a smart button
 to the motorcycle registry view form to acces the repair history of the motorcycle.
 Task Id:3427355 Dev: Odoo Team 4